### PR TITLE
fix table style

### DIFF
--- a/lib/MediaWiki/Table/Tiny.pm
+++ b/lib/MediaWiki/Table/Tiny.pm
@@ -16,7 +16,7 @@ sub table {
     my $border = ($args{border} // 1) ? 1 : 0;
     my @res;
 
-    push @res, '{| class="$class" style="$style" border="$border"', "\n";
+    push @res, "{| class=\"$class\" style=\"$style\" border=\"$border\"", "\n";
     push @res, '|+', $args{caption}, "\n" if $args{caption};
     push @res, '|-', "\n";
     my $i = 0;


### PR DESCRIPTION
https://rt.cpan.org/Public/Bug/Display.html?id=122917 added ability to customise table style. Unfortunately, literal variable names were written. This should fix it (although the fix is not terribly elegant with the escaped doublequotes).